### PR TITLE
Update 02_CFN_DEPLOY_AHA.yml

### DIFF
--- a/02_CFN_DEPLOY_AHA.yml
+++ b/02_CFN_DEPLOY_AHA.yml
@@ -69,7 +69,8 @@ Conditions:
   UsingTeams: !Not [!Equals [!Ref MicrosoftTeamsWebhookURL, None]]
   UsingChime: !Not [!Equals [!Ref AmazonChimeWebhookURL, None]]
   UsingEventBridge: !Not [!Equals [!Ref EventBusName, None]]
-  UsingSecrets: !Or [!Condition UsingSlack, !Condition UsingTeams, !Condition UsingChime, !Condition UsingEventBridge]
+  UsingManagementAccountRole: !Not [!Equals [!Ref ManagementAccountRoleArn, None]]
+  UsingSecrets: !Or [!Condition UsingSlack, !Condition UsingTeams, !Condition UsingChime, !Condition UsingEventBridge, !Condition UsingManagementAccountRole]
   UsingCrossAccountRole: !Not [!Equals [!Ref ManagementAccountRoleArn, None]]
   UsingAccountIds: !Not [!Equals [!Ref AccountIDs, None]]  
 Parameters:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Fix to creation of Secrets Manager permissions.

Permission to access AssumeRoleArn secrets is now created when the ManagementAccountRoleArn parameter is specified (i.e. not Slack/Teams/Chime/EventBridge).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
