### PR TITLE
Skip alerts for some Events

### DIFF
--- a/BETA-terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
+++ b/BETA-terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
@@ -625,6 +625,7 @@ resource "aws_lambda_function" "AHA-LambdaFunction-PrimaryRegion" {
             "TO_EMAIL"            = var.ToEmail
             "MANAGEMENT_ROLE_ARN" = var.ManagementAccountRoleArn
             "ACCOUNT_IDS"         = var.ExcludeAccountIDs
+            "SKIP_LIST"           = var.SkipList
             "S3_BUCKET"           = join("",aws_s3_bucket.AHA-S3Bucket-PrimaryRegion[*].bucket)
         }
     }

--- a/BETA-terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
+++ b/BETA-terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
@@ -171,6 +171,12 @@ variable "ExcludeAccountIDs" {
     description = "If you would like to EXCLUDE any accounts from alerting, enter a .csv filename created with comma-seperated account numbers. Sample AccountIDs file name: aha_account_ids.csv. If not, leave the default empty."
 }
 
+variable "SkipList" {
+    description = "Skip sending alerts containing the following CSV list of strings e.g. AWS_VPN_SINGLE_TUNNEL_NOTIFICATION,AWS_VPN_REDUNDANCY_LOSS"
+    type        = string
+    default     = ""
+}
+
 ##### Resources for AHA Solution created below.
 
 # Random id generator

--- a/BETA-terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
+++ b/BETA-terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
@@ -173,8 +173,8 @@ variable "ExcludeAccountIDs" {
 
 variable "SkipList" {
     description = "Skip sending alerts containing the following CSV list of strings e.g. AWS_VPN_SINGLE_TUNNEL_NOTIFICATION,AWS_VPN_REDUNDANCY_LOSS"
-    type        = string
-    default     = ""
+    type = string
+    default = ""
 }
 
 ##### Resources for AHA Solution created below.

--- a/BETA-terraform/Terraform_DEPLOY_AHA/terraform.tfvars
+++ b/BETA-terraform/Terraform_DEPLOY_AHA/terraform.tfvars
@@ -24,6 +24,8 @@ EventSearchBack="1"
 Regions="all regions"
 ManagementAccountRoleArn=""
 ExcludeAccountIDs=""
+# Skip sending alerts containing the following CSV list of strings e.g. AWS_VPN_SINGLE_TUNNEL_NOTIFICATION,AWS_VPN_REDUNDANCY_LOSS 
+SkipList=""
 
 # commands to apply changes
 # terraform init

--- a/handler.py
+++ b/handler.py
@@ -45,6 +45,14 @@ def get_account_name(account_id):
     return account_name
 
 def send_alert(event_details, affected_accounts, affected_entities, event_type):
+    # check for comma separated list of events to skip
+    if "SKIP_LIST" in os.environ:
+        skip_list_string = os.environ['SKIP_LIST']
+        skip_list = skip_list_string.split(",")
+        event_arn = event_details['successfulSet'][0]['event']['arn']
+        for skip in skip_list:
+            if skip in event_arn:
+                return
     slack_url = get_secrets()["slack"]
     teams_url = get_secrets()["teams"]
     chime_url = get_secrets()["chime"]
@@ -109,6 +117,14 @@ def send_alert(event_details, affected_accounts, affected_entities, event_type):
             pass
 
 def send_org_alert(event_details, affected_org_accounts, affected_org_entities, event_type):
+    # check for comma separated list of events to skip
+    if "SKIP_LIST" in os.environ:
+        skip_list_string = os.environ['SKIP_LIST']
+        skip_list = skip_list_string.split(",")
+        event_arn = event_details['successfulSet'][0]['event']['arn']
+        for skip in skip_list:
+            if skip in event_arn:
+                return
     slack_url = get_secrets()["slack"]
     teams_url = get_secrets()["teams"]
     chime_url = get_secrets()["chime"]


### PR DESCRIPTION
 Skip alerts for some Event Types #14 

In the case of noisy alerts, looking for a way to reduce the noise by excluding some event types from generating alerts. This provides a user defined CSV list of Events to skip passed to the handler in the environment variable SKIP_LIST.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
