### PR TITLE
updated s3 resource to reflect aws provider upgrade to v4.0.

### DIFF
--- a/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
+++ b/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
@@ -198,20 +198,29 @@ resource "random_string" "resource_code" {
 resource "aws_s3_bucket" "AHA-S3Bucket-PrimaryRegion" {
     count      = "${var.ExcludeAccountIDs != "" ? 1 : 0}"
     bucket     = "aha-bucket-${var.aha_primary_region}-${random_string.resource_code.result}"
-    acl        = "private"
     tags = {
       Name        = "aha-bucket"
     }
 }
 
+resource "aws_s3_bucket_acl" "AHA-S3Bucket-PrimaryRegion" {
+  count      = "${var.ExcludeAccountIDs != "" ? 1 : 0}"
+  bucket = aws_s3_bucket.AHA-S3Bucket-PrimaryRegion[count.index].id
+  acl    = "private"
+}
 resource "aws_s3_bucket" "AHA-S3Bucket-SecondaryRegion" {
     count      = "${var.aha_secondary_region != "" && var.ExcludeAccountIDs != "" ? 1 : 0}"
     provider   = aws.secondary_region
     bucket     = "aha-bucket-${var.aha_secondary_region}-${random_string.resource_code.result}"
-    acl        = "private"
     tags = {
       Name        = "aha-bucket"
     }
+}
+
+resource "aws_s3_bucket_acl" "AHA-S3Bucket-SecondaryRegion" {
+  count      = "${var.aha_secondary_region != "" && var.ExcludeAccountIDs != "" ? 1 : 0}"
+  bucket = aws_s3_bucket.AHA-S3Bucket-SecondaryRegion[count.index].id
+  acl    = "private"
 }
 
 resource "aws_s3_bucket_object" "AHA-S3Object-PrimaryRegion" {
@@ -782,4 +791,3 @@ resource "aws_lambda_permission" "AHA-LambdaSchedulePermission-SecondaryRegion" 
     function_name = aws_lambda_function.AHA-LambdaFunction-SecondaryRegion[0].arn
     source_arn    = aws_cloudwatch_event_rule.AHA-LambdaSchedule-SecondaryRegion[0].arn
 }
-


### PR DESCRIPTION
*Issue #, if available:*
Updates s3 resource to reflect aws provider upgrade to v4.0. based on  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade\#acl-argument
Without this upgrade Terraform plan will result in the following error:

````
➜  Terraform_DEPLOY_AHA git:(main) ✗ terraform plan
╷
│ Error: Value for unconfigurable attribute
│ 
│   with aws_s3_bucket.AHA-S3Bucket-PrimaryRegion,
│   on Terraform_DEPLOY_AHA.tf line 201, in resource "aws_s3_bucket" "AHA-S3Bucket-PrimaryRegion":
│  201:     acl        = "private"
│ 
│ Can't configure a value for "acl": its value will be decided automatically based on the result of applying this configuration.
╵
╷
│ Error: Value for unconfigurable attribute
│ 
│   with aws_s3_bucket.AHA-S3Bucket-SecondaryRegion,
│   on Terraform_DEPLOY_AHA.tf line 211, in resource "aws_s3_bucket" "AHA-S3Bucket-SecondaryRegion":
│  211:     acl        = "private"
│ 
│ Can't configure a value for "acl": its value will be decided automatically based on the result of applying this configuration.
╵
````

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
