### PR TITLE
Fix Terraform error for single region AssumeRoleArn secret

### DIFF
--- a/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
+++ b/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
@@ -413,7 +413,7 @@ resource "aws_secretsmanager_secret" "AssumeRoleArn" {
         "Name"          = "AHA-AssumeRoleArn"
     }
     dynamic "replica" {
-      for_each = var.aha_secondary_region == "" ? [0] : [1]
+      for_each = var.aha_secondary_region == "" ? [] : [1]
       content {
         region = var.aha_secondary_region
       }


### PR DESCRIPTION
*Description of changes:*

When deploying to an Organisation member account, in a single region, using Terraform there is an error:

```
│ Error: error creating Secrets Manager Secret: InvalidParameterException: Invalid replica region.
│
│   with aws_secretsmanager_secret.AssumeRoleArn[0],
│   on Terraform_DEPLOY_AHA.tf line 416, in resource "aws_secretsmanager_secret" "AssumeRoleArn":
│  416: resource "aws_secretsmanager_secret" "AssumeRoleArn" {
│
```

This change resolves that error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
