### PR TITLE
Fix Terraform to work on mac arm

### DIFF
--- a/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
+++ b/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
@@ -29,20 +29,16 @@ provider "aws" {
 locals {
     source_files = ["../../handler.py", "../../messagegenerator.py"]
 }
-data "template_file" "t_file" {
-    count = "${length(local.source_files)}"
-    template = "${file(element(local.source_files, count.index))}"
-}
 data "archive_file" "lambda_zip" {
     type          = "zip"
     output_path   = "lambda_function.zip"
     source {
       filename = "${basename(local.source_files[0])}"
-      content  = "${data.template_file.t_file.0.rendered}"
+      content  = "${templatefile(local.source_files[0], {})}"
     }
     source {
       filename = "${basename(local.source_files[1])}"
-      content  = "${data.template_file.t_file.1.rendered}"
+      content  = "${templatefile(local.source_files[1], {})}"
   }
 }
 


### PR DESCRIPTION
The template_file data provider is deprecated and not available on macOS m1/m2 machines. This repo states it requires terraform 1.0+, there is a templatefile() function built into terraform 1.0+

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
