### PR TITLE
Add Feishu Bot Webhook

### DIFF
--- a/CFN_DEPLOY_AHA.yml
+++ b/CFN_DEPLOY_AHA.yml
@@ -15,9 +15,10 @@ Metadata:
           - S3Key
       - Label:
           default: >-
-            Communication Channels - Slack/Microsoft Teams/Amazon Chime And/or
+            Communication Channels - Slack/Feishu Bot/Microsoft Teams/Amazon Chime And/or
             EventBridge
         Parameters:
+          - FeishuWebhookURL
           - SlackWebhookURL
           - MicrosoftTeamsWebhookURL
           - AmazonChimeWebhookURL
@@ -49,6 +50,8 @@ Metadata:
         default: Name of .zip file in S3 Bucket
       SlackWebhookURL:
         default: Slack Webhook URL
+      FeishuWebhookURL:
+        default: Feishu Bot Webhook Url
       MicrosoftTeamsWebhookURL:
         default: Microsoft Teams Webhook URL
       AmazonChimeWebhookURL:
@@ -68,11 +71,12 @@ Metadata:
       AccountIDs:
         default: Exclude any account numbers?        
 Conditions:
+  UsingFeishu: !Not [!Equals [!Ref FeishuWebhookURL, None]]
   UsingSlack: !Not [!Equals [!Ref SlackWebhookURL, None]]
   UsingTeams: !Not [!Equals [!Ref MicrosoftTeamsWebhookURL, None]]
   UsingChime: !Not [!Equals [!Ref AmazonChimeWebhookURL, None]]
   UsingEventBridge: !Not [!Equals [!Ref EventBusName, None]]
-  UsingSecrets: !Or [!Condition UsingSlack, !Condition UsingTeams, !Condition UsingChime, !Condition UsingEventBridge, !Condition UsingCrossAccountRole]
+  UsingSecrets: !Or [!Condition UsingSlack, !Condition UsingFeishu, !Condition UsingTeams, !Condition UsingChime, !Condition UsingEventBridge, !Condition UsingCrossAccountRole]
   UsingCrossAccountRole: !Not [!Equals [!Ref ManagementAccountRoleArn, None]]
   NotUsingMultiRegion: !Equals [!Ref SecondaryRegion, 'No']
   UsingMultiRegion: !Not [!Equals [!Ref SecondaryRegion, 'No']]
@@ -148,6 +152,11 @@ Parameters:
       you wish to send the alerts to the AWS EventBridge. Note: By ingesting
       these alerts to AWS EventBridge, you can integrate with 35 SaaS vendors
       such as DataDog/NewRelic/PagerDuty. If you don't prefer to use EventBridge, leave the default (None).
+    Type: String
+    Default: None
+  FeishuWebhookURL:
+    Description: >-
+      Enter the Feishu Bot Webhook URL. If you don't prefer to use Feishu, leave the default (None).
     Type: String
     Default: None
   SlackWebhookURL:
@@ -451,6 +460,7 @@ Resources:
                    - 'secretsmanager:ListSecretVersionIds'
                    - 'secretsmanager:GetSecretValue'
                   Resource: 
+                   - !If [UsingFeishu, !Sub '${FeishuChannelSecret}', !Ref AWS::NoValue]
                    - !If [UsingTeams, !Sub '${MicrosoftChannelSecret}', !Ref AWS::NoValue]
                    - !If [UsingSlack, !Sub '${SlackChannelSecret}', !Ref AWS::NoValue]
                    - !If [UsingEventBridge, !Sub '${EventBusNameSecret}', !Ref AWS::NoValue]
@@ -576,6 +586,22 @@ Resources:
       Tags:
         - Key: HealthCheckMicrosoft
           Value: ChannelID
+  FeishuChannelSecret:
+    Type: 'AWS::SecretsManager::Secret'
+    Condition: UsingFeishu   
+    Properties:
+      Name: FeishuChannelID
+      Description: Feishu Channel ID Secret
+      ReplicaRegions:
+        !If 
+        - UsingMultiRegion
+        - [{ Region: !Sub '${SecondaryRegion}' }]
+        - !Ref "AWS::NoValue"
+      SecretString:
+        Ref: FeishuWebhookURL
+      Tags:
+        - Key: HealthCheckFeishu
+          Value: ChannelID
   SlackChannelSecret:
     Type: 'AWS::SecretsManager::Secret'
     Condition: UsingSlack   
@@ -624,6 +650,7 @@ Resources:
       Tags:
         - Key: HealthCheckChime
           Value: ChannelID
+          
   AssumeRoleSecret:
     Type: 'AWS::SecretsManager::Secret'
     Condition: UsingCrossAccountRole    

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [Introduction](#introduction)
 - [Architecture](#architecture)
 - [Configuring an Endpoint](#configuring-an-endpoint)
+  * [Creating a Feishu Bot Webhook URL](#creating-a-feishu-bot-webhook-url)
   * [Creating a Amazon Chime Webhook URL](#creating-a-amazon-chime-webhook-url)
   * [Creating a Slack Webhook URL](#creating-a-slack-webhook-url)
   * [Creating a Microsoft Teams Webhook URL](#creating-a-microsoft-teams-webhook-url)
@@ -27,7 +28,7 @@
 - [Troubleshooting](#troubleshooting)
 
 # Introduction
-AWS Health Aware (AHA) is an automated notification tool for sending well-formatted AWS Health Alerts to Amazon Chime, Slack, Microsoft Teams, E-mail or an AWS Eventbridge compatible endpoint as long as you have Business or Enterprise Support.
+AWS Health Aware (AHA) is an automated notification tool for sending well-formatted AWS Health Alerts to Amazon Chime, Feishu, Slack, Microsoft Teams, E-mail or an AWS Eventbridge compatible endpoint as long as you have Business or Enterprise Support.
 
 # Architecture
 
@@ -53,6 +54,13 @@ AWS Health Aware (AHA) is an automated notification tool for sending well-format
 
 # Configuring an Endpoint
 AHA can send to multiple endpoints (webhook URLs, Email or EventBridge). To use any of these you'll need to set it up before-hand as some of these are done on 3rd party websites. We'll go over some of the common ones here.
+
+## Creating a Feishu Bot Webhook URL
+**maybe you need to add a bot in your chat room**
+
+Please refer to the [official document](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/bot-v3/bot-overview) of Feishu to add. Do not support custom keywords/IP list/signature.
+
+Copy the Webhook URL to prevent it from being abused.
 
 ## Creating a Amazon Chime Webhook URL
 **You will need to have access to create a Amazon Chime room and manage webhooks.**


### PR DESCRIPTION
*Issue #, if available:*
no issue

*Description of changes:*

**Summary**
add Feishu bot channel

**Detail**
_messagegenerator.py_ add

- func get_message_for_feishu
- func get_org_message_for_feishu

_handler.py_   add
- import the new func
- feishu secret feishu_url
- send feishu alert func send_to_feishu


_CFN_DEPLOY_AHA.yml_ add

- add FeishuWebhookURL
- add UsingFeishu
- add feishu parameters

Maybe it may not be the best, but the functionality is well tested.
Hope to be approved to make it more popular and stronger. Thanks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
