### PR TITLE
fix-single-region-deploy-error-invalid-replica-on-aws-secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+
+# AHA Lambda Function package
+lambda_function.zip
+
+# ---> Terraform
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# tf lock file
+.terraform.lock.hcl
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*

--- a/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
+++ b/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
@@ -204,6 +204,7 @@ resource "aws_s3_bucket" "AHA-S3Bucket-PrimaryRegion" {
 }
 
 resource "aws_s3_bucket_acl" "AHA-S3Bucket-PrimaryRegion" {
+    count  = var.ExcludeAccountIDs != "" ? 1 : 0
     bucket = aws_s3_bucket.AHA-S3Bucket-PrimaryRegion[0].id
     acl    = "private"
 }
@@ -427,7 +428,7 @@ resource "aws_secretsmanager_secret" "AssumeRoleArn" {
         "Name"          = "AHA-AssumeRoleArn"
     }
     dynamic "replica" {
-      for_each = var.aha_secondary_region == "" ? [0] : [1]
+      for_each = var.aha_secondary_region == "" ? [] : [1]
       content {
         region = var.aha_secondary_region
       }
@@ -663,7 +664,7 @@ resource "aws_lambda_function" "AHA-LambdaFunction-PrimaryRegion" {
     memory_size                    = 128
     timeout                        = 600
     filename                       = data.archive_file.lambda_zip.output_path
-    source_code_hash               = filebase64sha256(data.archive_file.lambda_zip.output_path)
+    source_code_hash               = data.archive_file.lambda_zip.output_base64sha256
 #    s3_bucket                      = var.S3Bucket
 #    s3_key                         = var.S3Key
     reserved_concurrent_executions = -1
@@ -710,7 +711,7 @@ resource "aws_lambda_function" "AHA-LambdaFunction-SecondaryRegion" {
     memory_size                    = 128
     timeout                        = 600
     filename                       = data.archive_file.lambda_zip.output_path
-    source_code_hash               = filebase64sha256(data.archive_file.lambda_zip.output_path)
+    source_code_hash               = data.archive_file.lambda_zip.output_base64sha256
 #    s3_bucket                      = var.S3Bucket
 #    s3_key                         = var.S3Key
     reserved_concurrent_executions = -1


### PR DESCRIPTION
* [Issue 52](https://github.com/aws-samples/aws-health-aware/issues/52)

*Description of changes:*

* Added ```.gitignore``` containing ignore rules for terraform and for generated file ```lambda_function.zip``` during terraform plan/apply.
* Added missing ```count``` expression in ```Terraform_DEPLOY_AHA.tf``` for ```resource "aws_s3_bucket_acl" "AHA-S3Bucket-PrimaryRegion"```
* Fixed ```for_each``` condition for  ```aha_secondary_region``` to have proper empty value if secondary_region is not set on dynamic ```replica``` value in ```resource "aws_secretsmanager_secret" "AssumeRoleArn"```
* Updated ```source_code_hash``` variable on both Lambda Functions to use the newly available value of  ```output_base64sha256``` from datasource on the archive_file resource instead of the ```filebase64sha256``` terraform function.

**Please Note**: This PR would also [PR-32](https://github.com/aws-samples/aws-health-aware/pull/32) on this repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
