### PR TITLE
Remove deprecated template_file call

### DIFF
--- a/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
+++ b/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
@@ -29,20 +29,16 @@ provider "aws" {
 locals {
     source_files = ["../../handler.py", "../../messagegenerator.py"]
 }
-data "template_file" "t_file" {
-    count = "${length(local.source_files)}"
-    template = "${file(element(local.source_files, count.index))}"
-}
 data "archive_file" "lambda_zip" {
     type          = "zip"
     output_path   = "lambda_function.zip"
     source {
       filename = "${basename(local.source_files[0])}"
-      content  = "${data.template_file.t_file.0.rendered}"
+      content  = file("${local.source_files[0]}")
     }
     source {
       filename = "${basename(local.source_files[1])}"
-      content  = "${data.template_file.t_file.1.rendered}"
+      content  = file("${local.source_files[1]}")
   }
 }
 


### PR DESCRIPTION
The `template` provider is [deprecated](https://registry.terraform.io/providers/hashicorp/template/latest/docs) by Hashicorp. Remove the data resource calling the template function and use calls to the builtin `file` function in the lambda_zip resource.

*Issue #56:*

Remove the `template_file t_file` data resource which uses the `template` function and update the `lambda_zip` resource to call the `file` function to get the lambda script contents directly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
