### PR TITLE
Remove deprecated module

### DIFF
--- a/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
+++ b/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
@@ -29,20 +29,20 @@ provider "aws" {
 locals {
     source_files = ["${path.module}/../../handler.py", "${path.module}/../../messagegenerator.py"]
 }
-data "template_file" "t_file" {
+data "local_file" "t_file" {
     count = "${length(local.source_files)}"
-    template = "${file(element(local.source_files, count.index))}"
+    filename = "${element(local.source_files, count.index)}"
 }
 data "archive_file" "lambda_zip" {
     type          = "zip"
     output_path   = "${path.module}/lambda_function.zip"
     source {
       filename = "${basename(local.source_files[0])}"
-      content  = "${data.template_file.t_file.0.rendered}"
+      content  = "${data.local_file.t_file[0].content}"
     }
     source {
       filename = "${basename(local.source_files[1])}"
-      content  = "${data.template_file.t_file.1.rendered}"
+      content  = "${data.local_file.t_file[1].content}"
   }
 }
 


### PR DESCRIPTION
*Issue:* https://github.com/aws-samples/aws-health-aware/issues/56 https://github.com/aws-samples/aws-health-aware/issues/64

*Description of changes:*
use `file` instead of `template_file`, and also support for running code on Mac

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
