### PR TITLE
Prevent duplicate affected entities in non org mode

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -408,8 +408,7 @@ def get_affected_entities(health_client, event_arn, is_org_mode, affected_accoun
                     entity.pop("entityArn") #remove entityArn to avoid confusion with the arn of the entityValue (not present)
                     entity.pop("eventArn") #remove eventArn duplicate of detail.arn
                     entity.pop("lastUpdatedTime") #remove for brevity
-                    if is_org_mode:
-                        entity['awsAccountName'] = account_name
+                    entity['awsAccountName'] = account_name
                     affected_entity_array.append(entity)
                 
     else:
@@ -429,8 +428,7 @@ def get_affected_entities(health_client, event_arn, is_org_mode, affected_accoun
                 )  # remove entityArn to avoid confusion with the arn of the entityValue (not present)
                 entity.pop("eventArn")  # remove eventArn duplicate of detail.arn
                 entity.pop("lastUpdatedTime")  # remove for brevity
-                if is_org_mode:
-                    entity["awsAccountName"] = get_account_name(entity['awsAccountId'])
+                entity["awsAccountName"] = get_account_name(entity['awsAccountId'])
                 affected_entity_array.append(entity)
 
     return affected_entity_array

--- a/handler.py
+++ b/handler.py
@@ -428,7 +428,6 @@ def get_affected_entities(health_client, event_arn, is_org_mode, affected_accoun
                 )  # remove entityArn to avoid confusion with the arn of the entityValue (not present)
                 entity.pop("eventArn")  # remove eventArn duplicate of detail.arn
                 entity.pop("lastUpdatedTime")  # remove for brevity
-                entity["awsAccountName"] = get_account_name(entity['awsAccountId'])
                 affected_entity_array.append(entity)
 
     return affected_entity_array


### PR DESCRIPTION
**The Issue:**
Currently when not using org mode AHA will report duplicate affected entities when an event has a high number of impacted entities. This is due to the `get_health_accounts` function returning a list with an account ID appended for each iteration of the `describe_affected_entities` paginator, resulting in a list of the same single account ID repeated several times.

The `get_affected_entities` function then takes this list of duplicate account IDs (since in non org mode there is only one account being polled) and adds the same affected entities for each item in the list.

**The Proposed Solution:**
The updated code reworks the `get_affected_entities` function so that it better handles both org mode and non org mode by having the for loop over the impacted accounts run only for org mode and making the `affected_accounts` parameter optional so that it does not need to be passed when in non org mode.

The `describe_events` function now does not need to call `get_health_accounts` and only calls `get_affected_entities`, which has the added benefit of removing a redundant call to describe the affected entities. It also deletes the `get_health_accounts` function altogether as it is no longer needed anywhere in the lambda. The `affected_accounts` variable is populated once the affected entities are pulled by pulling it from the first entity in the `affected_entities` list so that it can still be added to the DynamoDB item.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
