### PR TITLE
Add support for Slack 'triggers' webhooks - streamline webhook handling logic

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -85,42 +85,30 @@ def send_alert(event_details, affected_accounts, affected_entities, event_type):
         except URLError as e:
             print("Server connection failed: ", e.reason)
             pass
-    if "hooks.slack.com/services" in slack_url:
-        try:
-            print("Sending the alert to Slack Webhook Channel")
-            send_to_slack(
-                get_message_for_slack(
-                    event_details,
-                    event_type,
-                    affected_accounts,
-                    resources,
-                    slack_webhook="webhook",
-                ),
-                slack_url,
-            )
-        except HTTPError as e:
-            print("Got an error while sending message to Slack: ", e.code, e.reason)
-        except URLError as e:
-            print("Server connection failed: ", e.reason)
-            pass
-    if "hooks.slack.com/workflows" in slack_url:
-        try:
-            print("Sending the alert to Slack Workflows Channel")
-            send_to_slack(
-                get_message_for_slack(
-                    event_details,
-                    event_type,
-                    affected_accounts,
-                    resources,
-                    slack_webhook="workflow",
-                ),
-                slack_url,
-            )
-        except HTTPError as e:
-            print("Got an error while sending message to Slack: ", e.code, e.reason)
-        except URLError as e:
-            print("Server connection failed: ", e.reason)
-            pass
+    #Slack Notification Handling
+    if slack_url is not "None":
+        for slack_webhook_type in ["services", "triggers", "workflows"]:
+            if ("hooks.slack.com/" + slack_webhook_type) in slack_url:
+                try:
+                    send_to_slack(
+                        get_message_for_slack(
+                            event_details,
+                            event_type,
+                            affected_accounts,
+                            resources,
+                            slack_webhook_type,
+                        ),
+                        slack_url,
+                    )
+                    break
+                except HTTPError as e:
+                    print("Got an error while sending message to Slack: ", e.code, e.reason)
+                except URLError as e:
+                    print("Server connection failed: ", e.reason)
+                    pass
+            else:
+                print("Unsupported format in Slack Webhook")
+
     if "office.com/webhook" in teams_url:
         try:
             print("Sending the alert to Teams")

--- a/handler.py
+++ b/handler.py
@@ -106,8 +106,8 @@ def send_alert(event_details, affected_accounts, affected_entities, event_type):
                 except URLError as e:
                     print("Server connection failed: ", e.reason)
                     pass
-            else:
-                print("Unsupported format in Slack Webhook")
+        else:
+            print("Unsupported format in Slack Webhook")
 
     if "office.com/webhook" in teams_url:
         try:

--- a/messagegenerator.py
+++ b/messagegenerator.py
@@ -11,7 +11,7 @@ import time
 def get_message_for_slack(event_details, event_type, affected_accounts, affected_entities, slack_webhook):
     message = ""
     summary = ""
-    if slack_webhook == "webhook":
+    if slack_webhook == "services": #Handle "Incoming Webhook" webhooks
         if len(affected_entities) >= 1:
             affected_entities = "\n".join(affected_entities)
             if affected_entities == "UNKNOWN":
@@ -70,7 +70,7 @@ def get_message_for_slack(event_details, event_type, affected_accounts, affected
                     }
                 ]
             }
-    else:
+    else: #Handle 'workflows' or 'triggers' webhooks
         if len(affected_entities) >= 1:
             affected_entities = "\n".join(affected_entities)
             if affected_entities == "UNKNOWN":


### PR DESCRIPTION
*Issue #83*

*Description of changes:*
Added handling for webhooks using Slack's /triggers path in the URL (related to Workflow Builder 2.0).  Format of the message remains the same when using Workflows. Streamlined the logic in determining the Slack webhook type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.