### PR TITLE
Removed hardcoded AWS partition name

### DIFF
--- a/CFN_DEPLOY_AHA.yml
+++ b/CFN_DEPLOY_AHA.yml
@@ -294,7 +294,7 @@ Resources:
                           Service: lambda.amazonaws.com
                         Action: sts:AssumeRole
                   ManagedPolicyArns:
-                    - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+                    - arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
                   Path: /
                   Policies:
                     - PolicyName: aha-lambda-copier
@@ -305,13 +305,13 @@ Resources:
                             Action:
                               - s3:GetObject
                             Resource:
-                              - 'arn:aws:s3:::${S3Bucket}*'
+                              - 'arn:${AWS::Partition}:s3:::${S3Bucket}*'
                           - Effect: Allow
                             Action:
                               - s3:PutObject
                               - s3:DeleteObject
                             Resource:
-                              - !Join ['', [ 'arn:aws:s3:::', !Ref AHA2ndRegionBucket, '*']]
+                              - !Join ['', [ 'arn:${AWS::Partition}:s3:::', !Ref AHA2ndRegionBucket, '*']]
               CopyAHAFunction:
                 Type: AWS::Lambda::Function
                 DependsOn: AHA2ndRegionBucket
@@ -440,8 +440,8 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: 
-                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*'
-                  - !If [UsingMultiRegion, !Sub 'arn:aws:logs:${SecondaryRegion}:${AWS::AccountId}:*', !Ref AWS::NoValue]
+                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*'
+                  - !If [UsingMultiRegion, !Sub 'arn:${AWS::Partition}:logs:${SecondaryRegion}:${AWS::AccountId}:*', !Ref AWS::NoValue]
               - !If 
                 - UsingSecrets
                 - Effect: Allow
@@ -459,31 +459,31 @@ Resources:
                    - !If
                      - UsingMultiRegionTeams
                      - !Sub 
-                       - 'arn:aws:secretsmanager:${SecondaryRegion}:${AWS::AccountId}:secret:${SecretNameWithSha}' 
+                       - 'arn:${AWS::Partition}:secretsmanager:${SecondaryRegion}:${AWS::AccountId}:secret:${SecretNameWithSha}'
                        - { SecretNameWithSha: !Select [1, !Split [':secret:', !Sub '${MicrosoftChannelSecret}' ]]}
                      - !Ref AWS::NoValue
                    - !If
                      - UsingMultiRegionSlack
                      - !Sub 
-                       - 'arn:aws:secretsmanager:${SecondaryRegion}:${AWS::AccountId}:secret:${SecretNameWithSha}' 
+                       - 'arn:${AWS::Partition}:secretsmanager:${SecondaryRegion}:${AWS::AccountId}:secret:${SecretNameWithSha}'
                        - { SecretNameWithSha: !Select [1, !Split [':secret:', !Sub '${SlackChannelSecret}' ]]}
                      - !Ref AWS::NoValue
                    - !If
                      - UsingMultiRegionEventBridge
                      - !Sub 
-                       - 'arn:aws:secretsmanager:${SecondaryRegion}:${AWS::AccountId}:secret:${SecretNameWithSha}' 
+                       - 'arn:${AWS::Partition}:secretsmanager:${SecondaryRegion}:${AWS::AccountId}:secret:${SecretNameWithSha}'
                        - { SecretNameWithSha: !Select [1, !Split [':secret:', !Sub '${EventBusNameSecret}' ]]}
                      - !Ref AWS::NoValue
                    - !If
                      - UsingMultiRegionChime
                      - !Sub 
-                       - 'arn:aws:secretsmanager:${SecondaryRegion}:${AWS::AccountId}:secret:${SecretNameWithSha}' 
+                       - 'arn:${AWS::Partition}:secretsmanager:${SecondaryRegion}:${AWS::AccountId}:secret:${SecretNameWithSha}'
                        - { SecretNameWithSha: !Select [1, !Split [':secret:', !Sub '${ChimeChannelSecret}' ]]}
                      - !Ref AWS::NoValue
                    - !If
                      - UsingMultiRegionCrossAccountRole
                      - !Sub 
-                       - 'arn:aws:secretsmanager:${SecondaryRegion}:${AWS::AccountId}:secret:${SecretNameWithSha}' 
+                       - 'arn:${AWS::Partition}:secretsmanager:${SecondaryRegion}:${AWS::AccountId}:secret:${SecretNameWithSha}'
                        - { SecretNameWithSha: !Select [1, !Split [':secret:', !Sub '${AssumeRoleSecret}' ]]}
                      - !Ref AWS::NoValue
                 - !Ref 'AWS::NoValue'
@@ -504,14 +504,14 @@ Resources:
                 Action:
                   - dynamodb:ListTables
                 Resource: 
-                  - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:*'
-                  - !If [UsingMultiRegion, !Sub 'arn:aws:dynamodb:${SecondaryRegion}:${AWS::AccountId}:*', !Ref AWS::NoValue]
+                  - !Sub 'arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:*'
+                  - !If [UsingMultiRegion, !Sub 'arn:${AWS::Partition}:dynamodb:${SecondaryRegion}:${AWS::AccountId}:*', !Ref AWS::NoValue]
               - Effect: Allow
                 Action:
                   - ses:SendEmail
                 Resource: 
-                  - !Sub 'arn:aws:ses:${AWS::Region}:${AWS::AccountId}:*'
-                  - !If [UsingMultiRegion, !Sub 'arn:aws:ses:${SecondaryRegion}:${AWS::AccountId}:*', !Ref AWS::NoValue]
+                  - !Sub 'arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:*'
+                  - !If [UsingMultiRegion, !Sub 'arn:${AWS::Partition}:ses:${SecondaryRegion}:${AWS::AccountId}:*', !Ref AWS::NoValue]
               - Effect: Allow
                 Action:
                   - dynamodb:UpdateTimeToLive
@@ -528,14 +528,14 @@ Resources:
                 Action:
                   - events:PutEvents
                 Resource: 
-                  - !Sub 'arn:aws:events:${AWS::Region}:${AWS::AccountId}:event-bus/${EventBusName}'
-                  - !If [UsingMultiRegion, !Sub 'arn:aws:events:${SecondaryRegion}:${AWS::AccountId}:event-bus/${EventBusName}', !Ref AWS::NoValue]
+                  - !Sub 'arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${EventBusName}'
+                  - !If [UsingMultiRegion, !Sub 'arn:${AWS::Partition}:events:${SecondaryRegion}:${AWS::AccountId}:event-bus/${EventBusName}', !Ref AWS::NoValue]
               - !If 
                 - UsingAccountIds
                 - Effect: Allow
                   Action:
                     - s3:GetObject
-                  Resource: !Sub 'arn:aws:s3:::${S3Bucket}/${AccountIDs}'
+                  Resource: !Sub 'arn:${AWS::Partition}:s3:::${S3Bucket}/${AccountIDs}'
                 - !Ref 'AWS::NoValue'                     
               - !If 
                 - UsingCrossAccountRole

--- a/CFN_MGMT_ROLE.yml
+++ b/CFN_MGMT_ROLE.yml
@@ -18,7 +18,7 @@ Resources:
               - sts:AssumeRole
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${OrgMemberAccountId}:root'
+              AWS: !Sub 'arn:${AWS::Partition}:iam::${OrgMemberAccountId}:root'
       Policies:
         - PolicyName: AllowHealthCalls
           PolicyDocument:

--- a/handler.py
+++ b/handler.py
@@ -1003,7 +1003,7 @@ def get_sts_token(service):
     assumeRoleArn = get_secrets()["ahaassumerole"]
     boto3_client = None
 
-    if "arn:aws:iam::" in assumeRoleArn:
+    if assumeRoleArn.startswith("arn:"):
         ACCESS_KEY = []
         SECRET_KEY = []
         SESSION_TOKEN = []

--- a/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
+++ b/terraform/Terraform_DEPLOY_AHA/Terraform_DEPLOY_AHA.tf
@@ -5,6 +5,8 @@
 
 data "aws_caller_identity" "current" {}
 
+data "aws_partition" "current" {}
+
 provider "aws" {
     region  = var.aha_primary_region
     default_tags {
@@ -473,8 +475,8 @@ data "aws_iam_policy_document" "AHA-LambdaPolicy-Document" {
           "logs:PutLogEvents",
     ]
     resources = [
-          "arn:aws:logs:${var.aha_primary_region}:${data.aws_caller_identity.current.account_id}:*",
-          "arn:aws:logs:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:*"
+          "arn:${data.aws_partition.current.partition}:logs:${var.aha_primary_region}:${data.aws_caller_identity.current.account_id}:*",
+          "arn:${data.aws_partition.current.partition}:logs:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:*"
     ]
   }
   statement {
@@ -499,8 +501,8 @@ data "aws_iam_policy_document" "AHA-LambdaPolicy-Document" {
           "dynamodb:ListTables",
     ]
     resources = [
-          "arn:aws:dynamodb:${var.aha_primary_region}:${data.aws_caller_identity.current.account_id}:*",
-          "arn:aws:dynamodb:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:*",
+          "arn:${data.aws_partition.current.partition}:dynamodb:${var.aha_primary_region}:${data.aws_caller_identity.current.account_id}:*",
+          "arn:${data.aws_partition.current.partition}:dynamodb:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:*",
     ]
   }
   statement {
@@ -509,8 +511,8 @@ data "aws_iam_policy_document" "AHA-LambdaPolicy-Document" {
           "ses:SendEmail",
     ]
     resources = [
-          "arn:aws:ses:${var.aha_primary_region}:${data.aws_caller_identity.current.account_id}:*",
-          "arn:aws:ses:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:*",
+          "arn:${data.aws_partition.current.partition}:ses:${var.aha_primary_region}:${data.aws_caller_identity.current.account_id}:*",
+          "arn:${data.aws_partition.current.partition}:ses:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:*",
     ]
   }
   statement {
@@ -528,8 +530,8 @@ data "aws_iam_policy_document" "AHA-LambdaPolicy-Document" {
     ]
     resources = [
           #aws_dynamodb_table.AHA-DynamoDBTable.arn
-          "arn:aws:dynamodb:${var.aha_primary_region}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodbtable}-${random_string.resource_code.result}",
-          "arn:aws:dynamodb:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodbtable}-${random_string.resource_code.result}",
+          "arn:${data.aws_partition.current.partition}:dynamodb:${var.aha_primary_region}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodbtable}-${random_string.resource_code.result}",
+          "arn:${data.aws_partition.current.partition}:dynamodb:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:table/${var.dynamodbtable}-${random_string.resource_code.result}",
     ]
   }
   dynamic "statement" {
@@ -544,8 +546,8 @@ data "aws_iam_policy_document" "AHA-LambdaPolicy-Document" {
       ]
       resources = [
           aws_secretsmanager_secret.SlackChannelID[0].arn,
-          "arn:aws:secretsmanager:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.SlackChannelID[0].arn),6)}"
-#          var.aha_secondary_region != "" ? "arn:aws:secretsmanager:${var.aha_secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.SlackChannelID[0].arn),6)}" : null
+          "arn:${data.aws_partition.current.partition}:secretsmanager:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.SlackChannelID[0].arn),6)}"
+#          var.aha_secondary_region != "" ? "arn:${data.aws_partition.current.partition}:secretsmanager:${var.aha_secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.SlackChannelID[0].arn),6)}" : null
       ]
     }
   }
@@ -561,7 +563,7 @@ data "aws_iam_policy_document" "AHA-LambdaPolicy-Document" {
       ]
       resources = [
           aws_secretsmanager_secret.MicrosoftChannelID[0].arn,
-          "arn:aws:secretsmanager:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.MicrosoftChannelID[0].arn),6)}"
+          "arn:${data.aws_partition.current.partition}:secretsmanager:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.MicrosoftChannelID[0].arn),6)}"
       ]
     }
   }
@@ -577,7 +579,7 @@ data "aws_iam_policy_document" "AHA-LambdaPolicy-Document" {
       ]
       resources = [
           aws_secretsmanager_secret.ChimeChannelID[0].arn,
-          "arn:aws:secretsmanager:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.ChimeChannelID[0].arn),6)}"
+          "arn:${data.aws_partition.current.partition}:secretsmanager:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.ChimeChannelID[0].arn),6)}"
       ]
     }
   }
@@ -593,7 +595,7 @@ data "aws_iam_policy_document" "AHA-LambdaPolicy-Document" {
       ]
       resources = [
           aws_secretsmanager_secret.EventBusName[0].arn,
-          "arn:aws:secretsmanager:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.EventBusName[0].arn),6)}"
+          "arn:${data.aws_partition.current.partition}:secretsmanager:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.EventBusName[0].arn),6)}"
       ]
     }
   }
@@ -609,7 +611,7 @@ data "aws_iam_policy_document" "AHA-LambdaPolicy-Document" {
       ]
       resources = [
           aws_secretsmanager_secret.AssumeRoleArn[0].arn,
-          "arn:aws:secretsmanager:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.AssumeRoleArn[0].arn),6)}"
+          "arn:${data.aws_partition.current.partition}:secretsmanager:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:secret:${element(split(":", aws_secretsmanager_secret.AssumeRoleArn[0].arn),6)}"
       ]
     }
   }
@@ -621,8 +623,8 @@ data "aws_iam_policy_document" "AHA-LambdaPolicy-Document" {
           "events:PutEvents",
       ]
       resources = [
-          "arn:aws:events:${var.aha_primary_region}:${data.aws_caller_identity.current.account_id}:event-bus/${var.EventBusName}",
-          "arn:aws:events:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:event-bus/${var.EventBusName}"
+          "arn:${data.aws_partition.current.partition}:events:${var.aha_primary_region}:${data.aws_caller_identity.current.account_id}:event-bus/${var.EventBusName}",
+          "arn:${data.aws_partition.current.partition}:events:${local.secondary_region}:${data.aws_caller_identity.current.account_id}:event-bus/${var.EventBusName}"
       ]
     }
   }
@@ -646,8 +648,8 @@ data "aws_iam_policy_document" "AHA-LambdaPolicy-Document" {
           "s3:GetObject",
       ]
       resources = [
-          "arn:aws:s3:::aha-bucket-${var.aha_primary_region}-${random_string.resource_code.result}/${var.ExcludeAccountIDs}",
-          "arn:aws:s3:::aha-bucket-${local.secondary_region}-${random_string.resource_code.result}/${var.ExcludeAccountIDs}",
+          "arn:${data.aws_partition.current.partition}:s3:::aha-bucket-${var.aha_primary_region}-${random_string.resource_code.result}/${var.ExcludeAccountIDs}",
+          "arn:${data.aws_partition.current.partition}:s3:::aha-bucket-${local.secondary_region}-${random_string.resource_code.result}/${var.ExcludeAccountIDs}",
       ]
     }
   }

--- a/terraform/Terraform_MGMT_ROLE/Terraform_MGMT_ROLE.tf
+++ b/terraform/Terraform_MGMT_ROLE/Terraform_MGMT_ROLE.tf
@@ -1,5 +1,7 @@
 # Deploy Cross-Account Role for PHD access
 
+data "aws_partition" "current" {}
+
 # Parameters
 provider "aws" {
     region  = var.aha_primary_region
@@ -48,7 +50,7 @@ resource "aws_iam_role" "AWSHealthAwareRoleForPHDEvents" {
                     Action    = "sts:AssumeRole"
                     Effect    = "Allow"
                     Principal = {
-                        AWS = "arn:aws:iam::${var.OrgMemberAccountId}:root"
+                        AWS = "arn:${data.aws_partition.current.partition}:iam::${var.OrgMemberAccountId}:root"
                     }
                 },
             ]


### PR DESCRIPTION
*Issue #, if available:* #89

*Description of changes:*

Remove the hardcoded use of the aws partition. We use the aws_partition provider for terraform, the AWS::Partition pseudo parameter in cloudformation, and only check that the Assume Role ARN starts with "arn:" inside the handler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
