### PR TITLE
Fix failedSet member access in non-org mode

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -801,11 +801,9 @@ def describe_events(health_client):
                 )
                 event_details = json.loads(event_details)
                 print("Event Details: ", event_details)
-                if event_details["successfulSet"] == []:
+                if not event_details["successfulSet"]:
                     print(
-                        "An error occured with account:",
-                        event_details["failedSet"][0]["awsAccountId"],
-                        "due to:",
+                        "An error occurred due to:",
                         event_details["failedSet"][0]["errorName"],
                         ":",
                         event_details["failedSet"][0]["errorMessage"],
@@ -908,9 +906,9 @@ def describe_org_events(health_client):
                 )
                 event_details = json.loads(event_details)
                 print("Event Details: ", event_details)
-                if event_details["successfulSet"] == []:
+                if not event_details["successfulSet"]:
                     print(
-                        "An error occured with account:",
+                        "An error occurred with account:",
                         event_details["failedSet"][0]["awsAccountId"],
                         "due to:",
                         event_details["failedSet"][0]["errorName"],


### PR DESCRIPTION
When calling describe_event_details we were trying to access the awsAccountId field. This only exists in the organization version of this call. Removed the access and fixed a spelling mistake.

*Issue #, if available:* #106

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
